### PR TITLE
Update methods to reflect platform information

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 // original: https://github.com/CoderPuppy/os-browserify
 var {
   DeviceEventEmitter,
-  NativeModules
+  NativeModules,
+  Platform
 } = require('react-native');
 var RNOS = NativeModules.RNOS;
 
@@ -34,7 +35,7 @@ exports.totalmem = function () {
 
 exports.cpus = function () { return [] };
 
-exports.type = function () { return 'Browser' };
+exports.type = function () { return 'React Native' };
 
 exports.release = function () {
     if (typeof navigator !== 'undefined') {
@@ -51,7 +52,7 @@ exports.networkInterfaces
 
 exports.arch = function () { return 'javascript' };
 
-exports.platform = function () { return 'browser' };
+exports.platform = function () { return Platform.OS };
 
 exports.tmpdir = exports.tmpDir = function () {
     return '/tmp';


### PR DESCRIPTION
Hi there. Thanks for this library!

This PR updates the implementations of the `type` and `platform` methods to reflect more accurate system information.

`type` has been updated to simply return "React Native"
`platform` has been updated to return the current platform, either `android`, `ios`, or whatever else might be returned by `Platform.OS`

I'm guessing this is going to break someone's something, but I think it more accurately reflects the `os` in question. I can't see how this module would be run in a browser environment, and as such I think it's misleading and inaccurate to return `browser` for those methods. I'd love to have a discussion around this if you disagree with my changes. Please let me know!

Thanks again!