### PR TITLE
Removed @Override

### DIFF
--- a/android/src/main/java/com/peel/react/RNOSModule.java
+++ b/android/src/main/java/com/peel/react/RNOSModule.java
@@ -28,7 +28,6 @@ public final class RNOSModule implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
In ReactNative 0.51.0  build failed because of error 
```
:react-native-os:compileReleaseJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
C:\xampp\htdocs\EvolutionApp\node_modules\react-native-os\android\src\main\java\com\peel\react\RNOSModule.java:31: error: method does not override or implement a method from a supertype
    @Override                                                
    ^
1 error
:react-native-os:compileReleaseJavaWithJavac FAILED
```