### PR TITLE
Defining requiresMainQueueSetup to remove React Native warning

### DIFF
--- a/ios/RNOS.m
+++ b/ios/RNOS.m
@@ -157,4 +157,8 @@ static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
     return ifaces;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 @end


### PR DESCRIPTION
iOS app shows React Native yellow box warning that RNOS module requires main queue setup since it overrides 'constantsToExport'.

This commit defines the function to suppress the warning.