### PR TITLE
fix 'React/RCTBridgeModule.h' file not found bug in hybrid ios app an…

### DIFF
--- a/RNOS.podspec
+++ b/RNOS.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+  s.name                = 'RNOS'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/aprock/react-native-os.git' }
+  s.platform              = :ios, '9.0'
+  s.ios.deployment_target = '9.0'
+  s.source_files        = 'ios/**/*.{h,m}'
+  s.exclude_files       = 'android/**/*'
+  s.exclude_files       = 'example/**/*'
+  s.dependency 'React'
+end

--- a/ios/RNOS.h
+++ b/ios/RNOS.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SCNetworkReachability.h>
 #import <React/RCTBridgeModule.h>
-#import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 
 @interface RNOS : NSObject<RCTBridgeModule, RCTInvalidating>


### PR DESCRIPTION
Resolve RNOS.h: 'React/RCTBridgeModule.h' file not found bug in hybrid ios app and add podspec file to support react-native link by podfile# pod install way.